### PR TITLE
Mfp auto signal pattern

### DIFF
--- a/src/app/layout/shell/signal-list/signal-list.component.ts
+++ b/src/app/layout/shell/signal-list/signal-list.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe, NgFor, NgIf } from '@angular/common';
+import { DatePipe } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -7,22 +7,23 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from '@angular/material/list';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { RouterLinkWithHref } from '@angular/router';
-import { BookmarksSignalStoreService } from '../../../store/bookmarks-signal/bookmarks-signal-store.service';
-import { MatListModule } from '@angular/material/list';
-import { MatIconModule } from '@angular/material/icon';
 import { tap } from 'rxjs';
-import { MatDividerModule } from '@angular/material/divider';
-import { MatButtonModule } from '@angular/material/button';
+import { BookmarksSignalStoreService } from '../../../store/bookmarks-signal/bookmarks-signal-store.service';
 
 @Component({
   selector: 'app-signal-list',
   standalone: true,
   imports: [
     DatePipe,
+    MatButtonModule,
     MatDividerModule,
     MatFormFieldModule,
     MatIconModule,
@@ -31,7 +32,6 @@ import { MatButtonModule } from '@angular/material/button';
     MatProgressBarModule,
     ReactiveFormsModule,
     RouterLinkWithHref,
-    MatButtonModule
   ],
   templateUrl: './signal-list.component.html',
   styleUrl: './signal-list.component.scss',
@@ -41,6 +41,11 @@ export class SignalListComponent {
   readonly store = inject(BookmarksSignalStoreService);
   private readonly cdRef = inject(ChangeDetectorRef);
 
+  /**
+   * Much like markForCheck, Signals in zone apps, do not trigger CD.
+   * In zoneless apps, with a new change detection scheduler, you can expect signals to trigger CD but we're not there yet !
+   * https://github.com/angular/angular/issues/53841
+   */
   private readonly storeConnectionSub = this.store.connection$
     .pipe(
       takeUntilDestroyed(),

--- a/src/app/shared/utils/connect-source.fn.ts
+++ b/src/app/shared/utils/connect-source.fn.ts
@@ -1,0 +1,32 @@
+import { WritableSignal } from '@angular/core';
+import { finalize, merge, NEVER, Observable, share, tap } from 'rxjs';
+
+/**
+ * derived state with signals
+ *
+ * create a connection between the observable and the signal
+ *
+ * - automatic cleanup (Observables can automatically clean up the connections or listeners when the user goes to other pages and all subscribers have unsubscribed.)
+ * - reset and re-fetch (Observables can automatically reset state when the user goes to other pages and all subscribers have unsubscribed, and automatically re-fetch data when the user returns to a page that needs it)
+ * - automatic cancel (Observables can automatically cancel requests when the user goes to other pages and all subscribers have unsubscribed)
+ * - automatic defer (Observables can represent data sources but wait for subscribers instead of prematurely consuming them)
+ * read more
+ * https://dev.to/mfp22/introducing-the-auto-signal-pattern-1a5h
+ */
+export function connectSource<T>(
+  source$: Observable<T>,
+  state: WritableSignal<T>,
+) {
+  const initialState = state();
+  // merge the source observable with a NEVER observable because the source can sometimes self complete and that will trigger finalize to run
+  return merge(source$, NEVER).pipe(
+    // set the signal state to the state that came from the observable
+    tap((s) => state.set(s)),
+    // when all the subscribers are done set it back to the initial state
+    // sometimes the source can self complete and that will trigger finalize to run
+    // we want finalize to happen when all the subscribers unsubscribe (trick: merge the source observable with a NEVER observable)
+    finalize(() => state.set(initialState)),
+    // it should only do this once no matter how many subscribers has
+    share(),
+  );
+}

--- a/src/app/shared/utils/inject-auto-connect.function.ts
+++ b/src/app/shared/utils/inject-auto-connect.function.ts
@@ -1,0 +1,18 @@
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { inject, ProviderToken } from '@angular/core';
+import { Observable } from 'rxjs';
+/**
+ * We need to make sure that the connection has a subscription
+ * Read more
+ * https://dev.to/mfp22/introducing-the-auto-signal-pattern-1a5h
+ * @param token
+ * @returns service
+ */
+export function injectAutoConnect<
+  T,
+  Service extends { connection$: Observable<T> },
+>(token: ProviderToken<Service>): Service {
+  const service = inject(token);
+  service.connection$.pipe(takeUntilDestroyed()).subscribe();
+  return service;
+}

--- a/src/app/store/bookmarks-signal/bookmarks-signal-store.service.ts
+++ b/src/app/store/bookmarks-signal/bookmarks-signal-store.service.ts
@@ -7,12 +7,9 @@ import {
   defer,
   distinctUntilChanged,
   filter,
-  finalize,
   map,
   merge,
-  NEVER,
   of,
-  share,
   Subject,
   switchMap,
   tap,
@@ -22,6 +19,7 @@ import {
   BookmarkApiResponse,
   BookmarkService,
 } from '../../shared/services/bookmark/bookmark.service';
+import { connectSource } from '../../shared/utils/connect-source.fn';
 
 export interface BookmarksState {
   bookmarks: Bookmark[];
@@ -136,27 +134,6 @@ export class BookmarksSignalStoreService {
     this.searchResultsChange$,
     this.pageChange$,
   );
-  /**
-   * derived state with signals
-   *
-   * create a connection between the observable and the signal
-   *
-   * - automatic cleanup (Observables can automatically clean up the connections or listeners when the user goes to other pages and all subscribers have unsubscribed.)
-   * - reset and re-fetch (Observables can automatically reset state when the user goes to other pages and all subscribers have unsubscribed, and automatically re-fetch data when the user returns to a page that needs it)
-   * - automatic cancel (Observables can automatically cancel requests when the user goes to other pages and all subscribers have unsubscribed)
-   * - automatic defer (Observables can represent data sources but wait for subscribers instead of prematurely consuming them)
-   */
-  connection$ = merge(this.newState$, NEVER).pipe(
-    // set the signal state to the state that came from the observable
-    tap((state) => {
-      console.log('new state: ', { state });
-      this.state.set(state);
-    }),
-    // when all the subscribers are done set it back to the initial state
-    // sometimes the source can self complete and that will trigger finalize to run
-    // we want finalize to happen when all the subscribers unsubscribe (trick: merge the source observable with a NEVER observable)
-    finalize(() => this.state.set(defaultState)),
-    // it should only do this once no matter how many subscribers has
-    share(),
-  );
+
+  connection$ = connectSource(this.newState$, this.state);
 }


### PR DESCRIPTION
Extract signal store functionality into separate functions:
-  connectSource which creates a connection between the observable and the signal
- injectAutoConnect to make sure that the connection has a subscription